### PR TITLE
[JENKINS-19212] Add "useSSO" config option.

### DIFF
--- a/src/main/java/de/theit/jenkins/crowd/CrowdSecurityRealm.java
+++ b/src/main/java/de/theit/jenkins/crowd/CrowdSecurityRealm.java
@@ -118,6 +118,11 @@ public class CrowdSecurityRealm extends AbstractPasswordBasedSecurityRealm {
 	/** Specifies whether nested groups can be used. */
 	public final boolean nestedGroups;
 
+	/** Don't use SSO, only REST API authentication. */
+	// TODO: Currently this just disables CrowdServletFilter,
+	// (auto-logout), maybe worth disabling other SSO handling too.
+	public final boolean useSSO;
+
 	/**
 	 * The number of minutes to cache authentication validation in the session.
 	 * If this value is set to 0, each HTTP request will be authenticated with
@@ -156,13 +161,14 @@ public class CrowdSecurityRealm extends AbstractPasswordBasedSecurityRealm {
 	@DataBoundConstructor
 	public CrowdSecurityRealm(String url, String applicationName,
 			String password, String group, boolean nestedGroups,
-			int sessionValidationInterval) {
+			int sessionValidationInterval, boolean useSSO) {
 		this.url = url.trim();
 		this.applicationName = applicationName.trim();
 		this.password = password.trim();
 		this.group = group.trim();
 		this.nestedGroups = nestedGroups;
 		this.sessionValidationInterval = sessionValidationInterval;
+		this.useSSO = useSSO;
 	}
 
 	/**
@@ -266,6 +272,10 @@ public class CrowdSecurityRealm extends AbstractPasswordBasedSecurityRealm {
 		}
 
 		Filter defaultFilter = super.createFilter(filterConfig);
+
+		if (!useSSO) {
+			return defaultFilter;
+		}
 
 		return new CrowdServletFilter(this, this.configuration, defaultFilter);
 	}

--- a/src/main/resources/de/theit/jenkins/crowd/CrowdSecurityRealm/config.jelly
+++ b/src/main/resources/de/theit/jenkins/crowd/CrowdSecurityRealm/config.jelly
@@ -44,6 +44,9 @@ THE SOFTWARE.
 		<f:entry title="${%Session validation interval}" field="sessionValidationInterval">
 			<f:textbox default="2" />
 		</f:entry>
+		<f:entry title="${%Use SSO}" field="useSSO">
+			<f:checkbox default="true" />
+		</f:entry>
 	</f:advanced>
 	<f:validateButton method="testConnection" title="${%Check Connection}"
 		with="url,applicationName,password,group" />

--- a/src/main/resources/de/theit/jenkins/crowd/CrowdSecurityRealm/help-useSSO.html
+++ b/src/main/resources/de/theit/jenkins/crowd/CrowdSecurityRealm/help-useSSO.html
@@ -1,0 +1,6 @@
+<div>  
+  Whether to use SSO cookie to control user session lifetime (in addition to REST
+  API authentication). Note that using SSO requires both Crowd and Jenkins
+  servers to be in the same domain. If you have servers in different domain, you
+  have to disable this setting to make authentication work.
+</div>


### PR DESCRIPTION
It's still on by default, but when disabled, don't auto-logout due to lack
of SSO cookie. Typical situation when there's no cookie is when Crowd and
Jenkins servers are in different domains.
