### PR TITLE
JENKINS-27070: Fix https connection issue and logs "SEVERE: Host connection pool not found"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.509.3</version>
+        <version>2.17</version>
     </parent>
 
     <artifactId>crowd2</artifactId>
@@ -53,7 +53,7 @@
     <repositories>
         <repository>
             <id>atlassian</id>
-            <url>https://m2proxy.atlassian.com/repository/public</url>
+            <url>https://maven.atlassian.com/content/repositories/public/</url>
         </repository>
         <repository>
             <id>repo.jenkins-ci.org</id>
@@ -74,33 +74,17 @@
         </pluginRepository>
     </pluginRepositories>
 
-
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5</version>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <properties>
+        <jenkins.version>1.625.3</jenkins.version>
+        <java.level>7</java.level>
+        <findbugs.failOnError>false</findbugs.failOnError>
+    </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.atlassian.crowd</groupId>
             <artifactId>crowd-integration-client-rest</artifactId>
-            <version>2.7.1</version>
+            <version>2.8.8</version>
         </dependency>
 
         <dependency>

--- a/src/main/resources/de/theit/jenkins/crowd/CrowdSecurityRealm/config.jelly
+++ b/src/main/resources/de/theit/jenkins/crowd/CrowdSecurityRealm/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
 @(#)config.jelly
 

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
   This plugin enables use of <a href="http://www.atlassian.com/crowd">Atlassian Crowd</a>
   as an authentication source. It uses Crowd's REST API (available since Crowd 2.1)


### PR DESCRIPTION
Upgrade to a recent plugin POM to allow to release
+ Upgrade the requirement to Java 7 and thus Jenkins 1.625.3
+ JENKINS-27070: Upgrade to the latest version of crowd-integration-client supporting Java 7 and that integrates httpcomponents 4.x to avoid errors like this reported by httpclient 3.x which isn't supported (see : https://issues.apache.org/jira/browse/HTTPCLIENT-799):

Sep 16, 2014 6:24:27 PM org.apache.commons.httpclient.MultiThreadedHttpConnectionManager freeConnection
SEVERE: Host connection pool not found, hostConfig=HostConfiguration[host=XXXXX]
