### PR TITLE
Downgrade crowd integration client to 2.8.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
     <properties>
         <jenkins.version>2.121.1</jenkins.version>
-        <crowd-integration-client-rest.version>3.2.1</crowd-integration-client-rest.version>
+        <crowd-integration-client-rest.version>2.8.8</crowd-integration-client-rest.version>
         <apache-httpcomponents-client-4-api-plugin.version>4.5.5-3.0</apache-httpcomponents-client-4-api-plugin.version>
         <!-- JUnit dependency versions -->
         <junit.version>4.12</junit.version>
@@ -177,6 +177,23 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>display-info</id>
+                        <configuration>
+                            <rules>
+                                <requireUpperBoundDeps>
+                                    <excludes combine.children="append">
+                                        <exclude>org.apache.commons:commons-lang3</exclude>
+                                    </excludes>
+                                </requireUpperBoundDeps>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -193,6 +210,10 @@
                 <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpclient-cache</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
Downgrade crowd integration client to keep align with Jenkins, as the crowd integration client 3.2.1 requires guava 18.0, which is not binary compatible with guava 11.x bundled in Jenkins.

Test with Jenkins 2.121.1 and Crowd 2.12.0.