### PR TITLE
Correct logging

### DIFF
--- a/src/main/java/de/theit/jenkins/crowd/CrowdConfigurationService.java
+++ b/src/main/java/de/theit/jenkins/crowd/CrowdConfigurationService.java
@@ -358,7 +358,7 @@ public class CrowdConfigurationService {
                 try {
                     int index = 0;
                     if (LOG.isLoggable(Level.FINE)) {
-                        LOG.fine("Retrieve list of groups with direct membership for user '"
+                        LOG.fine("Retrieve list of groups with nested membership for user '"
                                 + username + "'...");
                     }
                     while (true) {


### PR DESCRIPTION
Correct misleading logging when retrieving nested group membership from Crowd instance