### PR TITLE
JENKINS-59301 a solutions - Crowd 2 plugin not compatible with JDK11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <properties>
         <jenkins.version>2.163</jenkins.version>
         <crowd-integration-client-rest.version>4.0.2</crowd-integration-client-rest.version>
-        <apache-httpcomponents-client-4-api-plugin.version>4.5.13-1.0</apache-httpcomponents-client-4-api-plugin.version>
+        <apache-httpcomponents-client-4-api-plugin.version>4.5.5-3.0</apache-httpcomponents-client-4-api-plugin.version>
         <jenkins-mailer-plugin.version>1.21</jenkins-mailer-plugin.version>
         <java.level>8</java.level>
         <findbugs.failOnError>false</findbugs.failOnError>
@@ -88,11 +88,6 @@
     </pluginRepositories>
 
     <dependencies>
-    	<dependency>
-			<groupId>io.jenkins.plugins</groupId>
-			<artifactId>jaxb</artifactId>
-			<version>2.3.0.1</version>
-		</dependency>
         <dependency>
             <groupId>com.atlassian.crowd</groupId>
             <artifactId>crowd-integration-client-rest</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -46,9 +46,9 @@
     </contributors>
 
     <properties>
-        <jenkins.version>2.89.3</jenkins.version>
-        <crowd-integration-client-rest.version>2.8.8</crowd-integration-client-rest.version>
-        <apache-httpcomponents-client-4-api-plugin.version>4.5.5-3.0</apache-httpcomponents-client-4-api-plugin.version>
+        <jenkins.version>2.163</jenkins.version>
+        <crowd-integration-client-rest.version>4.0.2</crowd-integration-client-rest.version>
+        <apache-httpcomponents-client-4-api-plugin.version>4.5.13-1.0</apache-httpcomponents-client-4-api-plugin.version>
         <jenkins-mailer-plugin.version>1.21</jenkins-mailer-plugin.version>
         <java.level>8</java.level>
         <findbugs.failOnError>false</findbugs.failOnError>
@@ -88,6 +88,11 @@
     </pluginRepositories>
 
     <dependencies>
+    	<dependency>
+			<groupId>io.jenkins.plugins</groupId>
+			<artifactId>jaxb</artifactId>
+			<version>2.3.0.1</version>
+		</dependency>
         <dependency>
             <groupId>com.atlassian.crowd</groupId>
             <artifactId>crowd-integration-client-rest</artifactId>
@@ -105,6 +110,10 @@
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava</artifactId>
                 </exclusion>
+                <exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -141,7 +150,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.7</version>
+                <version>3.8</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/java/de/theit/jenkins/crowd/CrowdConfigurationService.java
+++ b/src/main/java/de/theit/jenkins/crowd/CrowdConfigurationService.java
@@ -290,7 +290,7 @@ public class CrowdConfigurationService {
                 isGroupMemberCache.put(username, new CacheEntry<>(cacheTTL, retval));
             }
         }
-        if(retval != null) {
+        if(retval == null) {
         	retval = false;
         }
         return retval;

--- a/src/main/java/de/theit/jenkins/crowd/CrowdConfigurationService.java
+++ b/src/main/java/de/theit/jenkins/crowd/CrowdConfigurationService.java
@@ -290,6 +290,9 @@ public class CrowdConfigurationService {
                 isGroupMemberCache.put(username, new CacheEntry<>(cacheTTL, retval));
             }
         }
+        if(retval != null) {
+        	retval = false;
+        }
         return retval;
     }
 


### PR DESCRIPTION
A classloader hack was implemented before and after the rest method call. That is
only for JAVA >= 11
see https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/

update some dependencies
changed:
crowd rest client 4.0.2
commons-lang3 3.8

add minimum jenkins version to 2.163 because jaxb plugin need this


