### PR TITLE
JENKINS-64186 - fix Keep me signed in

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,7 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(failFast: false,
+            useAci: true,
+            configurations: [
+                [platform: 'linux', jdk: '8'],
+                [platform: 'linux', jdk: '11'],
+                [platform: 'windows', jdk: '8'],
+            ])

--- a/src/main/java/de/theit/jenkins/crowd/CrowdUser.java
+++ b/src/main/java/de/theit/jenkins/crowd/CrowdUser.java
@@ -82,7 +82,7 @@ public class CrowdUser implements UserDetails {
 	 */
 	@Override
 	public String getPassword() {
-		throw new UnsupportedOperationException("Not giving you the password");
+		return null;
 	}
 
 	/**

--- a/src/test/java/de/theit/jenkins/crowd/CrowdUserTest.java
+++ b/src/test/java/de/theit/jenkins/crowd/CrowdUserTest.java
@@ -38,7 +38,7 @@ public class CrowdUserTest {
 
 	@Test
 	public void testGetPassword() {
-		Assertions.assertThatThrownBy(() -> dummy.getPassword()).isInstanceOf(UnsupportedOperationException.class);
+		Assertions.assertThat(dummy.getPassword()).isNull();
 	}
 
 	@Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue](https://issues.jenkins.io/browse/JENKINS-65358)

These changes fixes this issue: https://issues.jenkins.io/browse/JENKINS-64186
In latest Jenkins version (my version: 2.319.1) when user clicks "Remember me" it fails with exception instead of logging the user. Issue has already accepted solution by other plugins, but it was not implemented yet. 


<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
