### PR TITLE
[JENKINS-68410] Depend on jaxb-plugin explicitly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,10 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mailer</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jaxb</artifactId>
+        </dependency>
         <!-- Tests -->
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,19 @@
                 <version>3.12.0</version>
             </dependency>
 
+            <!--
+                RequireUpperBoundDeps:
+                * io.jenkins.plugins:jaxb:2.3.0.1 depends on javax.xml.bind:jaxb-api:2.3.0
+                * com.thoughtworks.xstream:xstream:1.4.17 via org.jenkins-ci.main:jenkins-core:2.303.1
+                    depends on javax.xml.bind:jaxb-api:2.3.1
+                You can remove here if a newer version of jaxb-plugin is released.
+            -->
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>2.3.1</version>
+            </dependency>
+
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.303.x</artifactId>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Please have a look on https://issues.jenkins.io/browse/JENKINS-68410 for details.

crowd2-plugin requires jaxb-plugin: https://plugins.jenkins.io/jaxb/
It's met by apache-httpcomponents-client-4-api-4.5.13-1.0 depends on jaxb: https://plugins.jenkins.io/apache-httpcomponents-client-4-api/

Upcoming releases of apache-httpcomponents-client-4-api no longer depend on jaxb, and crowd2-plugin would no longer work on Java11.

Note: I don't know whether the next release of apache-httpcomponents-client-4-api is planned... just talking of possible situation.

So crowd2-plugin should depend on jaxb-plugin explicitly by itself.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira: https://issues.jenkins.io/browse/JENKINS-68410
- [x] Link to relevant pull requests, esp. upstream and downstream changes: N/A
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue: N/A

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
