### PR TITLE
[JENKINS-68459] Prepare Crowd 2 Integration for removal of JAXB and Java 11 requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,11 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mailer</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jaxb</artifactId>
+            <version>2.3.6-1</version>
+        </dependency>
         <!-- Tests -->
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,13 @@
                 <version>3.12.0</version>
             </dependency>
 
+            <!-- requireUpperBoundDeps between jaxb and mailer -->
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>javax-activation-api</artifactId>
+                <version>1.2.0-3</version>
+            </dependency>
+
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.303.x</artifactId>


### PR DESCRIPTION
See [JENKINS-68459](https://issues.jenkins.io/browse/JENKINS-68459). This plugin bundles `com.atlassian.crowd:crowd-integration-client-rest:jar:3.7.1`, which consumes JAXB. But when running on Java 9+, JAXB is not included on the classpath by default. The only way for a plugin to have access to JAXB when running on Jenkins 2.164 or later is to declare a plugin-to-plugin dependency on JAXB API plugin (recommended) or to embed JAXB into its `.jpi` file. This PR does the former to ensure that Crowd 2 Integration always has access to JAXB on its classpath. CC @DuMaM 