### PR TITLE
[JENKINS-68708] CrowdSecurityRealm: Prevent trim() calls on null strings

### DIFF
--- a/src/main/java/de/theit/jenkins/crowd/CrowdSecurityRealm.java
+++ b/src/main/java/de/theit/jenkins/crowd/CrowdSecurityRealm.java
@@ -57,6 +57,7 @@ import javax.servlet.ServletException;
 
 import jenkins.model.Jenkins;
 
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -211,10 +212,10 @@ public class CrowdSecurityRealm extends AbstractPasswordBasedSecurityRealm {
         this.socketTimeout = socketTimeout;
         this.httpTimeout = httpTimeout;
         this.httpMaxConnections = httpMaxConnections;
-        this.url = url.trim();
-        this.applicationName = applicationName.trim();
+        this.url = StringUtils.trimToEmpty(url);
+        this.applicationName = StringUtils.trimToEmpty(applicationName);
         this.password = password;
-        this.group = group.trim();
+        this.group = StringUtils.trimToEmpty(group);
         this.nestedGroups = nestedGroups;
         this.sessionValidationInterval = sessionValidationInterval;
         this.useSSO = useSSO;
@@ -260,7 +261,7 @@ public class CrowdSecurityRealm extends AbstractPasswordBasedSecurityRealm {
             String cookieTokenkey, Boolean useProxy, String httpProxyHost, String httpProxyPort,
             String httpProxyUsername, String httpProxyPassword, String socketTimeout,
             String httpTimeout, String httpMaxConnections, CacheConfiguration cache) {
-        this(url, applicationName, Secret.fromString(password.trim()), group, nestedGroups, sessionValidationInterval,
+        this(url, applicationName, Secret.fromString(password), group, nestedGroups, sessionValidationInterval,
                 useSSO,
                 cookieDomain, cookieTokenkey, useProxy, httpProxyHost, httpProxyPort, httpProxyUsername,
                 Secret.fromString(httpProxyPassword), socketTimeout, httpTimeout, httpMaxConnections, cache);

--- a/src/test/java/de/theit/jenkins/crowd/CrowdSecurityRealmTest.java
+++ b/src/test/java/de/theit/jenkins/crowd/CrowdSecurityRealmTest.java
@@ -1,0 +1,147 @@
+package de.theit.jenkins.crowd;
+
+import de.theit.jenkins.crowd.CrowdSecurityRealm.CacheConfiguration;
+
+import hudson.util.Secret;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class CrowdSecurityRealmTest {
+
+    // Needed for getDescriptor().save() in the compatibility constructor
+    @Rule public JenkinsRule jenkinsRule = new JenkinsRule();
+
+    @Test
+    public void testCrowdSecurityRealmConstructorWithTypicalData() {
+        String url = "https://crowd2/";
+        String applicationName = "Jenkins";
+        Secret password = Secret.fromString("crowd_password");
+        String group = "restricted_users";
+        boolean nestedGroups = true;
+        int sessionValidationInterval = 2;
+        boolean useSSO = true;
+        String cookieDomain = "cookie_domain";
+        String cookieTokenkey = "token_key";
+        boolean useProxy = true;
+        String httpProxyHost = "proxy_host";
+        String httpProxyPort = "8080";
+        String httpProxyUsername = "proxy_user";
+        Secret httpProxyPassword = Secret.fromString("proxy_password");
+        String socketTimeout = "20000";
+        String httpTimeout = "5000";
+        String httpMaxConnections = "20";
+        CacheConfiguration cache = new CacheConfiguration(20, 300);
+        CrowdSecurityRealm realm = new CrowdSecurityRealm(
+            url,
+            applicationName,
+            password,
+            group,
+            nestedGroups,
+            sessionValidationInterval,
+            useSSO,
+            cookieDomain,
+            cookieTokenkey,
+            useProxy,
+            httpProxyHost,
+            httpProxyPort,
+            httpProxyUsername,
+            httpProxyPassword,
+            socketTimeout,
+            httpTimeout,
+            httpMaxConnections,
+            cache);
+
+        Assertions.assertThat(realm.getCacheSize()).isEqualTo(20);
+        Assertions.assertThat(realm.getCacheTTL()).isEqualTo(300);
+    }
+
+    @Test
+    public void testCrowdSecurityRealmConstructorWithNullData() {
+        String url = null;
+        String applicationName = null;
+        Secret password = null;
+        String group = null;
+        boolean nestedGroups = false;
+        int sessionValidationInterval = 0;
+        boolean useSSO = false;
+        String cookieDomain = null;
+        String cookieTokenkey = null;
+        boolean useProxy = false;
+        String httpProxyHost = null;
+        String httpProxyPort = null;
+        String httpProxyUsername = null;
+        Secret httpProxyPassword = null;
+        String socketTimeout = null;
+        String httpTimeout = null;
+        String httpMaxConnections = null;
+        CacheConfiguration cache = null;
+        CrowdSecurityRealm realm = new CrowdSecurityRealm(
+            url,
+            applicationName,
+            password,
+            group,
+            nestedGroups,
+            sessionValidationInterval,
+            useSSO,
+            cookieDomain,
+            cookieTokenkey,
+            useProxy,
+            httpProxyHost,
+            httpProxyPort,
+            httpProxyUsername,
+            httpProxyPassword,
+            socketTimeout,
+            httpTimeout,
+            httpMaxConnections,
+            cache);
+
+        Assertions.assertThat(realm.getCacheSize()).isNull();
+        Assertions.assertThat(realm.getCacheTTL()).isNull();
+    }
+
+    @Test
+    public void testCrowdSecurityRealmDeprecatedConstructorWithNullData() {
+        String url = null;
+        String applicationName = null;
+        String password = null;
+        String group = null;
+        boolean nestedGroups = false;
+        int sessionValidationInterval = 0;
+        boolean useSSO = false;
+        String cookieDomain = null;
+        String cookieTokenkey = null;
+        boolean useProxy = false;
+        String httpProxyHost = null;
+        String httpProxyPort = null;
+        String httpProxyUsername = null;
+        String httpProxyPassword = null;
+        String socketTimeout = null;
+        String httpTimeout = null;
+        String httpMaxConnections = null;
+        CrowdSecurityRealm realm = new CrowdSecurityRealm(
+            url,
+            applicationName,
+            password,
+            group,
+            nestedGroups,
+            sessionValidationInterval,
+            useSSO,
+            cookieDomain,
+            cookieTokenkey,
+            useProxy,
+            httpProxyHost,
+            httpProxyPort,
+            httpProxyUsername,
+            httpProxyPassword,
+            socketTimeout,
+            httpTimeout,
+            httpMaxConnections);
+
+        Assertions.assertThat(realm.getCacheSize()).isNull();
+        Assertions.assertThat(realm.getCacheTTL()).isNull();
+    }
+
+}


### PR DESCRIPTION
```
*  [JENKINS-68708] CrowdSecurityRealm: Prevent trim() calls on null strings
   
   Replace trim() with StringUtils.trimToEmpty(), it trims strings as well
   and also converts null to an empty string.
   
   Don't use trim() in the compatibility constructor. Passwords should be
   used without trimming. Secret.fromString(null) returns a valid object.
   
   Add unit tests for CrowdSecurityRealm constructors.
   
   Signed-off-by: Pavel Roskin <plroskin@gmail.com>
```

https://issues.jenkins.io/browse/JENKINS-68708

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Manual testing performed:

* Ran "mvn verify" successfully
* Deployed the resulting crowd2.hpi to a Jenkins 2.346.2 server
* Removed cookieTokenkey, group and httpProxyPassword from `jenkins.yaml`
* Loaded the modified `jenkins.yaml`
* Logged out and logged in (crowd2 is used for authentication)
* Downloaded `jenkins.yaml`
* cookieTokenkey, group and httpProxyPassword are not in the downloaded `jenkins.yaml` as exprected
* Checked Jenkins log for any potential problems, did not find any.
