### PR TITLE
chore: remove warnings from CI logs for missing plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,14 +190,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <!-- Version specified in parent POM -->
+                <version>3.19.0</version>
             </plugin>
 
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <!-- Version specified in parent POM -->
+                <version>3.2.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>


### PR DESCRIPTION
Purpose of this PR is to remove those warnings

```
[2022-10-25T21:48:27.250Z] [WARNING] The POM for org.jenkins-ci.tools:maven-hpi-plugin:jar:3.34 is missing, no dependency information available
[2022-10-25T21:48:27.250Z] [WARNING] Failed to build parent project for org.jenkins-ci.plugins:crowd2:hpi:3.2.1-rc417.fda_b_b_64cb_934
[2022-10-25T21:48:27.250Z] [WARNING] 
[2022-10-25T21:48:27.251Z] [WARNING] Some problems were encountered while building the effective model for org.jenkins-ci.plugins:crowd2:hpi:3.2.1-rc417.fda_b_b_64cb_934
[2022-10-25T21:48:27.251Z] [WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-pmd-plugin is missing. @ org.jenkins-ci.plugins:crowd2:${revision}${changelist}, /home/jenkins/workspace/Plugins_crowd2-plugin_master/pom.xml, line 190, column 21
[2022-10-25T21:48:27.251Z] [WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-checkstyle-plugin is missing. @ org.jenkins-ci.plugins:crowd2:${revision}${changelist}, /home/jenkins/workspace/Plugins_crowd2-plugin_master/pom.xml, line 197, column 21
[2022-10-25T21:48:27.251Z] [WARNING] 
[2022-10-25T21:48:27.251Z] [WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[2022-10-25T21:48:27.251Z] [WARNING] 
[2022-10-25T21:48:27.251Z] [WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[2022-10-25T21:48:27.251Z] [WARNING] 
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
