### PR TITLE
chore: bump crowd2 plugin to 4.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/crowd2-plugin</gitHubRepo>
         <jenkins.version>2.346.1</jenkins.version>
-        <crowd-integration-client-rest.version>3.7.2</crowd-integration-client-rest.version>
+        <crowd-integration-client-rest.version>4.4.3</crowd-integration-client-rest.version>
         <findbugs.failOnError>false</findbugs.failOnError>
         <spotbugs.effort>Max</spotbugs.effort>
         <spotbugs.failOnError>true</spotbugs.failOnError>


### PR DESCRIPTION
Bump Crowd2 plugin to [4.4.3](https://mvnrepository.com/artifact/com.atlassian.crowd/crowd-integration-client-rest/4.4.3)
This version is latest one with 4 at the end. 
In in terms of API changes I didnt noticed any problems, so it should work without issues.
This should also allow to remove some workarounds done for java 11.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue