### PR TITLE
chore: update jenkins ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 buildPlugin(failFast: false,
             useContainerAgent: true,
             configurations: [
-                [platform: 'linux', jdk: '8'],
+                [platform: 'linux', jdk: '17'],
                 [platform: 'linux', jdk: '11'],
-                [platform: 'windows', jdk: '8'],
+                [platform: 'windows', jdk: '11'],
             ])


### PR DESCRIPTION
Since 3.2.1 this plugin dont support java 8, so we need to upgrade CI first according to current patterns.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
