### PR TITLE
deps: upgrade plugin parent POM from 4.57 to 4.61

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.57</version>
+        <version>4.61</version>
     </parent>
 
     <artifactId>crowd2</artifactId>
@@ -119,7 +119,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Adapts to https://github.com/mockito/mockito/pull/2945 by switching our dependency from `mockito-inline` to `mockito-core`.

Changes in dependabot PR: https://github.com/jenkinsci/crowd2-plugin/pull/173