### PR TITLE
Catch IllegalStateException

### DIFF
--- a/src/main/java/de/theit/jenkins/crowd/CrowdRememberMeServices.java
+++ b/src/main/java/de/theit/jenkins/crowd/CrowdRememberMeServices.java
@@ -127,6 +127,9 @@ public class CrowdRememberMeServices implements RememberMeServices {
                         authorities.addAll(this.configuration.getAuthoritiesForUser(user.getName()));
                         result = new CrowdAuthenticationToken(user.getName(), null, authorities, ssoToken);
                     }
+                // See: https://github.com/jenkinsci/jenkins/pull/4107                    
+                } catch (IllegalStateException ex) {
+                    LOG.log(Level.WARNING, "Encountered IllegalStateException. System init may not have completed yet.");
                 } catch (InvalidTokenException ex) {
                     LOG.log(Level.FINE, invalidToken(), ex);
                 } catch (ApplicationPermissionException ex) {


### PR DESCRIPTION
During my testing I have noticed that from time to time when restarting Jenkins, an `IllegalStateException` is thrown. This issue is similar to https://github.com/jenkinsci/jenkins/pull/4107 in fact it is the same issue as we make the same call in our code:

https://github.com/jenkinsci/crowd2-plugin/blob/ff4affe98a969c5bcd4de4211656a8db57e841b4/src/main/java/de/theit/jenkins/crowd/CrowdAuthenticationToken.java#L125

Before this patch the log looked like this:

```
Apr 24 08:23:18 Jenkins-McdCore java[516]: INFO: Jenkins stopped
Apr 24 08:23:19 Jenkins-McdCore java[516]: Apr 24, 2023 8:23:19 AM hudson.init.impl.InstallUncaughtExceptionHandler handleException
Apr 24 08:23:19 Jenkins-McdCore java[516]: WARNING: Caught unhandled exception with ID 2841997a-ee9d-4e6e-a1d0-e36079f288ec
Apr 24 08:23:19 Jenkins-McdCore java[516]: java.lang.IllegalStateException: Expected 1 instance of hudson.model.User$AllUsers but got 0
Apr 24 08:23:19 Jenkins-McdCore java[516]:         at hudson.ExtensionList.lookupSingleton(ExtensionList.java:454)
Apr 24 08:23:19 Jenkins-McdCore java[516]:         at hudson.model.User$AllUsers.getInstance(User.java:1098)
Apr 24 08:23:19 Jenkins-McdCore java[516]:         at hudson.model.User$AllUsers.get(User.java:1116)
Apr 24 08:23:19 Jenkins-McdCore java[516]:         at hudson.model.User.getOrCreateById(User.java:535)
Apr 24 08:23:19 Jenkins-McdCore java[516]:         at hudson.model.User.getById(User.java:638)
Apr 24 08:23:19 Jenkins-McdCore java[516]:         at de.theit.jenkins.crowd.CrowdAuthenticationToken.updateUserInfo(CrowdAuthenticationTok>
Apr 24 08:23:19 Jenkins-McdCore java[516]:         at de.theit.jenkins.crowd.CrowdRememberMeServices.autoLogin(CrowdRememberMeServices.java>
Apr 24 08:23:19 Jenkins-McdCore java[516]:         at de.theit.jenkins.crowd.CrowdServletFilter.doFilter(CrowdServletFilter.java:177)
```

The server would still restart but would produce `Oops! A problem occurred while processing the request.`.

After the patch:

```
Apr 24 20:13:22 Jenkins-CrowdAAD java[242796]: Apr 24, 2023 8:13:22 PM hudson.lifecycle.Lifecycle onStatusUpdate
Apr 24 20:13:22 Jenkins-CrowdAAD java[242796]: INFO: Jenkins stopped
Apr 24 20:13:23 Jenkins-CrowdAAD java[242796]: Apr 24, 2023 8:13:23 PM de.theit.jenkins.crowd.CrowdRememberMeServices autoLogin
Apr 24 20:13:23 Jenkins-CrowdAAD java[242796]: WARNING: Encountered IllegalStateException. System init may not have completed yet.
Apr 24 20:13:23 Jenkins-CrowdAAD java[242796]: Apr 24, 2023 8:13:23 PM hudson.security.HttpSessionContextIntegrationFilter2 hasInvalidSessionSeed
Apr 24 20:13:23 Jenkins-CrowdAAD java[242796]: WARNING: Encountered IllegalStateException trying to get a user. System init may not have completed yet. Invalidating user session.
Apr 24 20:13:25 Jenkins-CrowdAAD java[242796]: Running from: /opt/jenkins_home/jenkins.war
Apr 24 20:13:25 Jenkins-CrowdAAD java[242796]: webroot: /opt/jenkins_home/war
Apr 24 20:13:25 Jenkins-CrowdAAD java[242796]: Apr 24, 2023 8:13:25 PM winstone.Logger logInternal
Apr 24 20:13:25 Jenkins-CrowdAAD java[242796]: INFO: Beginning extraction from war file

```
