### PR TITLE
Explicitly use Atlassian repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,16 @@
             <id>maven.jenkins-ci.org</id>
             <url>https://repo.jenkins-ci.org/releases</url>
         </repository>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>atlassian-maven-external</id>
+            <url>https://packages.atlassian.com/maven-external/</url>
+        </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>


### PR DESCRIPTION
See https://github.com/jenkins-infra/helpdesk/issues/3842. This plugin currently depends on JCenter for Atlassian libraries, but JFrog has asked us to stop caching JCenter dependencies. Based on [this page](https://developer.atlassian.com/server/framework/atlassian-sdk/working-with-maven/), the dependencies we need are officially published at https://packages.atlassian.com/maven-external/ so fetch them from there directly. We choose `maven-external` rather than `maven-public` because the Crowd libraries are only available in `maven-external`, not `maven-public`.

To test this, I verified that I could run `mvn clean verify -DskipTests '-P!consume-incrementals,!might-produce-incrementals'` in a clean Docker container (without `~/.m2`) and without the JCenter cache:

```xml
diff --git a/pom.xml b/pom.xml
index 925ab62..e1076d4 100644
--- a/pom.xml
+++ b/pom.xml
@@ -73,18 +73,40 @@
 
     <repositories>
         <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
             <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/releases/</url>
         </repository>
         <repository>
-            <id>maven.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/releases</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>orphans</id>
+            <url>https://repo.jenkins-ci.org/artifactory/orphans/</url>
+        </repository>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/releases/</url>
         </pluginRepository>
     </pluginRepositories>

```